### PR TITLE
Fixing crash from example code in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ class Page extends SiteTree {
         $polls = Poll::get();
         if ($polls) { 
             $fields->addFieldsToTab('Root.Main', array(
-                new DropdownField('PollID', 'Poll', $polls->map(), $this->PollID, null, '--- Select a poll ---')
+                DropdownField::create('PollID', 'Poll', $polls->map(), $this->PollID)->setEmptyString('--- Select a poll ---'),
             ));
         }
         else {


### PR DESCRIPTION
The example code in the read me would cause a deprecated error when trying to load a page.

Fixes #15
