### PR TITLE
FIX Allowing multiple choice votes

### DIFF
--- a/code/PollChoice.php
+++ b/code/PollChoice.php
@@ -52,7 +52,6 @@ class PollChoice extends DataObject {
 		if($poll && !$poll->isVoted()) {
 			$this->Votes++;
 			$this->write();
-			$poll->markAsVoted();
 		}
 	}
 	

--- a/code/PollForm.php
+++ b/code/PollForm.php
@@ -63,6 +63,7 @@ class PollForm extends Form {
 			foreach($choices as $choice) {
 				$choice->addVote();
 			}
+			$form->poll->markAsVoted();
 		}
 		
 		// Redirect back to anchor (partly copied from Director::redirectBack)


### PR DESCRIPTION
Currently, if a user selects more than one choice for a multiple choice
poll only the first choice is recorded.

This is because `PollChoice::addVote()` checks if the user has voted or
not and only records the vote if they haven't but then it marks them as
having voted and all subsequent choices will be ignored.

Now we only execute `Poll::markAsVoted()` after all choices are recorded
