### PR TITLE
Removing the IsActive clause for dropdown

### DIFF
--- a/code/Poll.php
+++ b/code/Poll.php
@@ -25,18 +25,18 @@ class Poll extends DataObject implements PermissionProvider {
 	);
 	
 	static $searchable_fields = array(
-		'Title', 
+		'Title',
 		'IsActive'
 	);
-	
+
 	static $summary_fields = array(
 		'Title',
 		'IsActive',
 		'Embargo',
 		'Expiry'
 	); 
-	
-	static $default_sort = 'Created DESC';
+
+	static $default_sort = 'Title ASC';
 
 	private static $vote_handler_class = 'CookieVoteHandler';
 

--- a/code/Poll.php
+++ b/code/Poll.php
@@ -25,17 +25,17 @@ class Poll extends DataObject implements PermissionProvider {
 	);
 	
 	static $searchable_fields = array(
-		'Title',
+		'Title', 
 		'IsActive'
 	);
-
+	
 	static $summary_fields = array(
 		'Title',
 		'IsActive',
 		'Embargo',
 		'Expiry'
 	); 
-
+	
 	static $default_sort = 'Title ASC';
 
 	private static $vote_handler_class = 'CookieVoteHandler';

--- a/code/PollChoice.php
+++ b/code/PollChoice.php
@@ -29,13 +29,19 @@ class PollChoice extends DataObject {
 	static $default_sort = '"Order" ASC, "Created" ASC';
 	
 	function getCMSFields() {
-		$polls = DataObject::get('Poll');
-		$pollsMap = array();
-		if($polls) $pollsMap = $polls->map('ID', 'Title', '--- Select a poll ---');
-		
+		$activePolls = DataObject::get('Poll', '"IsActive" = 1');
+		$inactivePolls = DataObject::get('Poll', '"IsActive" = 0');
+
+		if($activePolls) $activePollsMap = $activePolls->map('ID', 'Title')->toArray();
+		if($inactivePolls) $inactivePollsMap = $inactivePolls->map('ID', 'Title')->toArray();
+
 		$fields = new FieldList(
 			new TextField('Title', 'Option', '', 80),
-			new DropdownField('PollID', 'Belongs to', $pollsMap),
+			new GroupedDropdownField('PollID', 'Belongs to',
+							array(
+								"Active" => $activePollsMap->toArray(),
+								"Inactive" => $inactivePollsMap->toArray()
+							)),
 			new ReadonlyField('Votes')
 			//new TextField('Order')
 		); 

--- a/code/PollChoice.php
+++ b/code/PollChoice.php
@@ -29,12 +29,12 @@ class PollChoice extends DataObject {
 	static $default_sort = '"Order" ASC, "Created" ASC';
 	
 	function getCMSFields() {
-		$polls = DataObject::get('Poll', '"IsActive" = 1'); 
+		$polls = DataObject::get('Poll');
 		$pollsMap = array();
 		if($polls) $pollsMap = $polls->map('ID', 'Title', '--- Select a poll ---');
 		
 		$fields = new FieldList(
-			new TextField('Title', '', '', 80),
+			new TextField('Title', 'Option', '', 80),
 			new DropdownField('PollID', 'Belongs to', $pollsMap),
 			new ReadonlyField('Votes')
 			//new TextField('Order')


### PR DESCRIPTION
When using the poll module, I wanted to set up some inactive polls but you cannot add choices to an inactive poll as the drop down is populated by `$polls = DataObject::get('Poll', '"IsActive" = 1');` I don't think the user should be restricted by this.

Thoughts? Did you have a reason for building it like this @mateusz?

Thanks!
