### PR TITLE
Add subsite support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,7 @@ master: SilverStripe 3.0.x
 - By default, each visitor, determined by browser cookie, can only vote once
 - Uses [Google chart API](http://code.google.com/apis/chart/) 
 - Supports single and multiple-choice polls
+- Supports Subsites
 
 ## Usage
 
@@ -193,4 +194,16 @@ whether a user has voted before.
 
 See `DatabaseVoteHandler` for an example.
 
+### Subsite support
 
+By defualt the Polls menu item will show in all subsites in the CMS. If you only want it to show in the main site, add to your `config/config.yml`:
+```yml
+Poll:
+  subsite_cms_show_in_menu: false
+```
+
+By default a poll created within a subsite will only be available in that subsite. To allow polls to be shared between subsites add to your `config/config.yml`:
+```yml
+Poll:
+  subsites_share_polls: true
+```

--- a/code/Poll.php
+++ b/code/Poll.php
@@ -6,6 +6,9 @@
  */
 class Poll extends DataObject implements PermissionProvider {
 	
+	private static $subsites_share_polls = false;
+	private static $subsite_cms_show_in_menu = true;
+
 	const COOKIE_PREFIX = 'SSPoll_';
 	
 	static $db = Array(
@@ -14,7 +17,8 @@ class Poll extends DataObject implements PermissionProvider {
 		'IsActive' => 'Boolean(1)',
 		'MultiChoice' => 'Boolean',
 		'Embargo' => 'SS_Datetime',
-		'Expiry' => 'SS_Datetime'
+		'Expiry' => 'SS_Datetime',
+		'SubsiteID' => 'Int',
 	);
 	static $has_one = array(
 		'Image' => 'Image'
@@ -120,8 +124,16 @@ class Poll extends DataObject implements PermissionProvider {
 		}
 				
 		$this->extend('updateCMSFields', $fields);
-		
-		return $fields; 
+
+		return $fields;
+	}
+
+	function onBeforeWrite() {
+		// Limit this poll to the subsite it is defined within
+		if (class_exists('Subsite') && !$this->subsites_share_polls) {
+			$this->SubsiteID = Subsite::currentSubsiteID();
+		}
+		return parent::onBeforeWrite();
 	}
 
 	function getTotalVotes() {

--- a/code/PollAdmin.php
+++ b/code/PollAdmin.php
@@ -8,5 +8,18 @@ class PollAdmin extends ModelAdmin {
 	static $managed_models = array(
 		'Poll'
 	);
-	
+
+	public function subsiteCMSShowInMenu() {
+		return Config::inst()->get('Poll', 'subsite_cms_show_in_menu');
+	}
+
+	public function getEditForm($id = null, $fields = null) {
+		$form = parent::getEditForm($id, $fields);
+		if (class_exists('Subsite') && !Config::inst()->get('Poll', 'subsites_share_polls')) {
+			$gridField = $form->Fields()->fieldByName($this->sanitiseClassName($this->modelClass));
+			$list = $gridField->getList()->filter(array('SubsiteID' => Subsite::currentSubsiteID()));
+			$gridField->setList($list);
+		}
+		return $form;
+	}
 }


### PR DESCRIPTION
By default it will be available in the CMS for subsites, and polls will not be shared between subsites.
Both of these can be changed through config.
